### PR TITLE
document units a bit better

### DIFF
--- a/src/agnsed.py
+++ b/src/agnsed.py
@@ -79,7 +79,9 @@ class agnsed:
         r_warm : float
             Outer radius of warm Compton region - units : Rg
         log_rout : float
-            log of outer disc radius - units : Rg
+            log of outer disc radius - units : Rg. 
+            If -ve, the outer disc radius is set to the radius where
+            self-gravity stops.
         fcol : float
             Colour temperature correction as described in Done et al. (2012)
             If -ve then follows equation 1 and 2 in Done et al. (2012).

--- a/src/agnsed.py
+++ b/src/agnsed.py
@@ -1012,6 +1012,8 @@ if __name__ == '__main__':
     fEs = agn.get_SED(as_flux=True)
     
     plt.loglog(Es, Es**2 * fEs, color='k')
+    plt.ylabel('Energy flux density [keV/cm$^2$/s/keV]')
+    plt.xlabel('Energy [keV]')
     plt.ylim(1e-4, 1)
     plt.show()
     

--- a/src/agnsed.py
+++ b/src/agnsed.py
@@ -263,10 +263,10 @@ class agnsed:
         ----------
         new_unit : {'cgs','cgs_wave', 'SI', 'counts'}, optional
             The default unit to use. The default is 'cgs'.
-             * cgs: the luminosity spectral density is in `u.erg/u.s/u.Hz`, use `agn.nugrid * u.Hz`
+             * cgs: the luminosity spectral density is in `u.erg/u.s/u.Hz`, use `agn.nu_grid * u.Hz`
              * counts: the luminosity spectral density is in `u.keV/u.s/u.keV`, use `agn.Egrid * u.keV`
              * cgs_wave: the luminosity spectral density is in `u.erg/u.s/u.AA`, use `agn.wavegrid * u.AA`
-             * SI: the luminosity spectral density is in `u.W/u.s/u.Hz`, use `agn.nugrid * u.Hz`
+             * SI: the luminosity spectral density is in `u.W/u.s/u.Hz`, use `agn.nu_grid * u.Hz`
             Integrated luminosities correspondingly lose /Hz or /AA.
             Fluxes correspondingly are per luminosity distance squared.
 

--- a/src/agnsed.py
+++ b/src/agnsed.py
@@ -263,8 +263,12 @@ class agnsed:
         ----------
         new_unit : {'cgs','cgs_wave', 'SI', 'counts'}, optional
             The default unit to use. The default is 'cgs'.
-            NOTE, the main cgs_wave will give spectra in erg/s/Angstrom,
-            while cgs gives in erg/s/Hz
+             * cgs: the luminosity spectral density is in `u.erg/u.s/u.Hz`, use `agn.nugrid * u.Hz`
+             * counts: the luminosity spectral density is in `u.keV/u.s/u.keV`, use `agn.Egrid * u.keV`
+             * cgs_wave: the luminosity spectral density is in `u.erg/u.s/u.AA`, use `agn.wavegrid * u.AA`
+             * SI: the luminosity spectral density is in `u.W/u.s/u.Hz`, use `agn.nugrid * u.Hz`
+            Integrated luminosities correspondingly lose /Hz or /AA.
+            Fluxes correspondingly are per luminosity distance squared.
 
         """
         #Checking valid units
@@ -360,7 +364,7 @@ class agnsed:
     
     def _calc_Ledd(self):
         """
-        Caclulate eddington Luminosity
+        Calculate eddington Luminosity
 
         """
         Ledd = 1.39e38 * self.M #erg/s
@@ -647,7 +651,7 @@ class agnsed:
 
         Returns
         -------
-        \pi * Bnu : 2D-array, shape=(len(nus), len(Ts))
+        pi * Bnu : 2D-array, shape=(len(nus), len(Ts))
             Black-body emission spectrum - Units : erg/s/cm^2/Hz
 
         """
@@ -683,7 +687,7 @@ class agnsed:
         """
         
         T4_ann = self.calc_Tnt(r)
-        if self.rep == True:
+        if self.rep:
             T4_ann = T4_ann + self.calc_Trep(r, self.Lx)
         
         Tann = T4_ann**(1/4)
@@ -751,7 +755,7 @@ class agnsed:
         """
         
         T4_ann = self.calc_Tnt(r)
-        if self.rep == True:
+        if self.rep:
             T4_ann = T4_ann + self.calc_Trep(r, self.Lx)
         
         kTann = self.k_B * T4_ann**(1/4) #ergs
@@ -1003,7 +1007,7 @@ if __name__ == '__main__':
     nus = agn.nu_grid
     Es = agn.Egrid
     
-       
+    
     agn.set_units('counts')
     fEs = agn.get_SED(as_flux=True)
     


### PR DESCRIPTION
From the example at the bottom, the units were not fully clear to me.

Some smaller changes:

\pi trips up a syntax error (need r""" """ or double backslash). 

== True is redundant for booleans

I would suggest to rename the .rep attribute to .reprocess for clarity.
